### PR TITLE
[Refactor] 엔드포인트 수정 및 user 토큰 파싱 시 userId 반환 제거

### DIFF
--- a/src/main/java/com/click/payment/controller/PaymentHistoryController.java
+++ b/src/main/java/com/click/payment/controller/PaymentHistoryController.java
@@ -27,7 +27,7 @@ public class PaymentHistoryController {
     private final PaymentHistoryService paymentHistoryService;
 
     // 전체 결제 내역 조회
-    @GetMapping("/{businessKey}")
+    @GetMapping("/all/{businessKey}")
     public List<PaymentHistory> getPaymentHistories(
         @PathVariable("businessKey") String businessKey
     ) {
@@ -61,10 +61,11 @@ public class PaymentHistoryController {
      */
     @PutMapping("/{payId}")
     public void updatePaymentHistoryState(
+        @RequestHeader("Authorization") String userToken,
         @PathVariable("payId") Long payId,
         @RequestBody UpdatePaymentHistoryRequest updatePaymentHistoryRequest
     ) {
-        paymentHistoryService.updatePaymentHistoryState(payId, updatePaymentHistoryRequest);
+        paymentHistoryService.updatePaymentHistoryState(userToken, payId, updatePaymentHistoryRequest);
     }
 
     /**
@@ -93,6 +94,4 @@ public class PaymentHistoryController {
     ) {
         return paymentHistoryService.getLastStandCard(userToken);
     }
-
-
 }

--- a/src/main/java/com/click/payment/domain/dto/response/LastStandCardResponse.java
+++ b/src/main/java/com/click/payment/domain/dto/response/LastStandCardResponse.java
@@ -4,23 +4,20 @@ import com.click.payment.domain.entity.LastStandCard;
 import java.util.UUID;
 
 public record LastStandCardResponse(
-    UUID userId,
     Integer code,
     Long cardId
 ) {
     // card가 null인 경우
-    public static LastStandCardResponse from(UUID userId, Integer code) {
+    public static LastStandCardResponse from(Integer code) {
         return new LastStandCardResponse(
-            userId,
             code,
             null
         );
     }
 
     // card가 존재하는 경우
-    public static LastStandCardResponse from(UUID userId, Integer code, LastStandCard card) {
+    public static LastStandCardResponse from(Integer code, LastStandCard card) {
         return new LastStandCardResponse(
-            userId,
             code,
             card.getCardId()
         );

--- a/src/main/java/com/click/payment/service/PaymentHistoryService.java
+++ b/src/main/java/com/click/payment/service/PaymentHistoryService.java
@@ -21,7 +21,7 @@ public interface PaymentHistoryService {
     SuccessPaymentResponse insertPaymentHistory(String businessKey, PaymentHistoryRequest req);
 
     // 결제 상태 수정
-    void updatePaymentHistoryState(Long payId, UpdatePaymentHistoryRequest req);
+    void updatePaymentHistoryState(String userToken, Long payId, UpdatePaymentHistoryRequest req);
 
     // payToken
     PayTokenResponse parsePayToken(String payToken);

--- a/src/main/java/com/click/payment/service/PaymentHistoryServiceImpl.java
+++ b/src/main/java/com/click/payment/service/PaymentHistoryServiceImpl.java
@@ -71,16 +71,21 @@ public class PaymentHistoryServiceImpl implements PaymentHistoryService {
     // 결제 상태 수정
     @Override
     @Transactional
-    public void updatePaymentHistoryState(Long payId, UpdatePaymentHistoryRequest req) {
+    public void updatePaymentHistoryState(String userToken, Long payId, UpdatePaymentHistoryRequest req) {
         PaymentHistory byBusinessIdAndPayId = paymentHistoryRepository.findByPayId(payId);
         if(byBusinessIdAndPayId.getPayId() == null) throw new NullPointerException("결제내역 오류");
 
-        // 카드 유효성 검사
-        
+        // userToken
+        UUID userId = jwtUtils.parseUserToken(userToken);
 
+        // 카드 유효성 검사
+
+
+        // 마지막 결제 카드 저장
+        LastStandCard lastStandCard = new LastStandCard(userId, req.cardId());
+        lastStandCardRepository.save(lastStandCard);
 
         // 계좌 유효성 검사
-
 
 
         // 환불 완료일 경우 환불 시간 업데이트
@@ -109,10 +114,10 @@ public class PaymentHistoryServiceImpl implements PaymentHistoryService {
 
         if (card != null) {
             code = 0;
-            return LastStandCardResponse.from(userId, code, card);
+            return LastStandCardResponse.from(code, card);
         } else {
             code = 1;
-            return LastStandCardResponse.from(userId, code);
+            return LastStandCardResponse.from(code);
         }
     }
 }


### PR DESCRIPTION
## 개요
결제 내역 전체 조회와 특정 결제 내역 조회의 엔드포인트가 같아,
결제 내역 전체 조회의 엔드포인트를 /all을 추가해 수정했습니다.
userId를 반환해서 주고 받는 것보단 user 토큰으로 파싱해서 하는 게 맞다고 판단하여 userId 반환하는 것을 제거했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트).
